### PR TITLE
set CLOEXEC bit on file descriptors

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -61,16 +61,19 @@ fn validate_socket(
 
 pub fn make_tcp_listener(fd: FdType) -> io::Result<TcpListener> {
     validate_socket(fd, libc::AF_INET, libc::SOCK_STREAM, "tcp socket")
+        .map(|fd| unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) })
         .map(|fd| unsafe { FromRawFd::from_raw_fd(fd) })
 }
 
 pub fn make_unix_listener(fd: FdType) -> io::Result<UnixListener> {
     validate_socket(fd, libc::AF_UNIX, libc::SOCK_STREAM, "unix socket")
+        .map(|fd| unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) })
         .map(|fd| unsafe { FromRawFd::from_raw_fd(fd) })
 }
 
 pub fn make_udp_socket(fd: FdType) -> io::Result<UdpSocket> {
     validate_socket(fd, libc::AF_INET, libc::SOCK_DGRAM, "udp socket")
+        .map(|fd| unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) })
         .map(|fd| unsafe { FromRawFd::from_raw_fd(fd) })
 }
 


### PR DESCRIPTION
Setting the CLOEXEC (close on exec) bit on file descriptors is needed on a unix-style system with fork and exec semantics to prevent accidentally cloning a socket when running an external binary.

In order to be imported from the command-line a file descriptor cannot have had its CLOEXEC set.  So set this bit now as early as makes sense.

Maybe a little documentation is in order?  That any file descriptor for a socket needs to owned by the ListenFD interface before any external binary is exec'd or this open socket will leak across to it.