### PR TITLE
Bump uuid dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ license = "MIT/Apache-2.0"
 libc = "0.2.40"
 
 [target."cfg(windows)".dependencies]
-uuid = "0.6.3"
+uuid = "0.8.2"
 winapi = { version = "0.3.4", features = ["winsock2", "processthreadsapi"] }


### PR DESCRIPTION
My project uses this crate, thank you for writing it. I'm already using the [docs.rs/uuid](uuid) crate, and I'd like to avoid having two copies of it in my Cargo dependencies. So I thought I'd upgrade this crate to use 0.8, not 0.6.