### PR TITLE
Port to `rustix`: Fewer `unsafe` blocks, and file descriptor ownership.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT/Apache-2.0"
 
 [target."cfg(not(windows))".dependencies]
-libc = "0.2.40"
+rustix = "0.31.3"
 
 [target."cfg(windows)".dependencies]
 uuid = "0.8.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! The `--no-pid` flag is necessary to ensure that the `LISTEN_PID` environment
 //! variable is not set or the socket passing will be prevented by the pid check.
 #[cfg(not(windows))]
-extern crate libc;
+extern crate rustix;
 #[cfg(windows)]
 extern crate uuid;
 #[cfg(windows)]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,11 +15,11 @@ use winapi::um::winsock2::{
 
 pub use self::RawSocket as FdType;
 
-pub fn make_tcp_listener(fd: FdType) -> io::Result<TcpListener> {
+pub fn make_tcp_listener(fd: FdType) -> Result<TcpListener, (io::Error, FdType)> {
     Ok(unsafe { FromRawSocket::from_raw_socket(fd) })
 }
 
-pub fn make_udp_socket(fd: FdType) -> io::Result<UdpSocket> {
+pub fn make_udp_socket(fd: FdType) -> Result<UdpSocket, (io::Error, FdType)> {
     Ok(unsafe { FromRawSocket::from_raw_socket(fd) })
 }
 


### PR DESCRIPTION
This ports listenfd to use the [rustix] crate in place of directly
using libc, on Unix platforms. Rustix provides safe APIs for libc-like
functionality, which for listenfd means it factors out several `unsafe`
blocks, and manages file descriptors with the `OwnedFd` type, which
tracks file descriptors ownership helping ensure fds are used only
within their intended lifetimes.

I've tested this on Linux with [systemfd] and [thttp].

[rustix]: https://github.com/bytecodealliance/rustix
[thttp]: https://github.com/davidedelpapa/thttp
[systemfd]: https://github.com/mitsuhiko/systemfd